### PR TITLE
Solved Issue #18, add feedback for SquatPage regarding hip angle (keeping chest up)

### DIFF
--- a/app/src/pages/exercises/SquatPage.js
+++ b/app/src/pages/exercises/SquatPage.js
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useState } from "react";
 import { Typography, Box, Paper, TextField, Button, IconButton, Modal } from '@mui/material';
 import WebcamBox from "../../components/Webcam";
 import detectPose from '../../utils/PoseDetector';
-import { checkSquats, setSquatCount } from '../../utils/Squat';
+import { checkChestUp, checkSquats, setSquatCount } from '../../utils/Squat';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 /**
@@ -19,8 +19,13 @@ import SettingsIcon from '@mui/icons-material/Settings';
 function SquatPage() {
     const webcamRef = useRef(null);
     const canvasRef = useRef(null);
-    const [targetKneeAngle, setTargetKneeAngle] = useState(70);
+
+    const [targetKneeAngle, setTargetKneeAngle] = useState(90);
     const [feedback, setFeedback] = useState("");
+
+    const [targetHipAngle, setTargetHipAngle] = useState(45);
+    const [hipAnglefeedback, setHipAngleFeedback] = useState("");
+
     const [currKneeAngle, setCurrKneeAngle] = useState(0);
     const [repCount, setRepCount] = useState(0);
     const [openModal, setOpenModal] = useState(false);
@@ -29,8 +34,13 @@ function SquatPage() {
         setTargetKneeAngle(event.target.value);
     };
 
+    const handleTargetHipAngleChange = (event) => {
+        setTargetHipAngle(event.target.value);
+    };
+
     const processPoseResults = (landmarks) => {
         checkSquats(landmarks, setFeedback, setCurrKneeAngle, setRepCount, targetKneeAngle);
+        checkChestUp(landmarks, setHipAngleFeedback, targetHipAngle);
     };
 
     const handleReset = () => {
@@ -98,7 +108,7 @@ function SquatPage() {
                     {feedback ? feedback : "Please Begin Rep!"}
                 </Typography>
                 <Typography variant="h6" style={{ color: 'red', marginBottom: '20px' }}>
-                    { }
+                    {hipAnglefeedback}
                 </Typography>
                 <Typography variant="h6" gutterBottom>
                     Knee Angle: {currKneeAngle.toFixed(0)}°
@@ -142,10 +152,18 @@ function SquatPage() {
                     </Typography>
                     <TextField
                         id="outlined-number"
-                        label="Target Knee Angle °"
+                        label="Target Knee Angle ° for Depth"
                         type="number"
                         value={targetKneeAngle}
                         onChange={handleTargetKneeAngleChange}
+                        sx={{ marginBottom: '20px' }}
+                    />
+                    <TextField
+                        id="outlined-number"
+                        label="Minimum Hip Angle ° (Chest Up)"
+                        type="number"
+                        value={targetHipAngle}
+                        onChange={handleTargetHipAngleChange}
                         sx={{ marginBottom: '20px' }}
                     />
                     <Button variant="contained" onClick={handleCloseModal}>

--- a/app/src/utils/Squat.js
+++ b/app/src/utils/Squat.js
@@ -11,8 +11,9 @@ let inSquatPosition = false;
  * @param {Function} onFeedbackUpdate A callback function that receives the feedback message about the squat depth and form.
  * @param {Function} setLeftKneeAngle A function to update the current knee angle for display purposes.
  * @param {Function} setRepCount A function to update the squat count after a full squat is completed.
+ * @param {number} targetKneeAngle The angle (in degrees) a user's knee must break (go below) to count as proper repetition.
  */
-export const checkSquats = (landmarks, onFeedbackUpdate, setCurrKneeAngle, setRepCount, targetKneeAngle = 70) => {
+export const checkSquats = (landmarks, onFeedbackUpdate, setCurrKneeAngle, setRepCount, targetKneeAngle = 90) => {
     const thresholdAngle = 160;
 
     const leftHip = landmarks[23];
@@ -49,6 +50,36 @@ export const checkSquats = (landmarks, onFeedbackUpdate, setCurrKneeAngle, setRe
         if (inSquatPosition) {
             feedback = "Excellent!"
         }
+    }
+
+    onFeedbackUpdate(feedback);
+};
+
+/**
+ * Monitors and provides feedback to ensure the user is keeping their chest up during the squat.
+ * Compares the angle formed by the shoulder, hip, and knee to determine if the chest is sagging.
+ *
+ * @param {Array} landmarks An array of pose landmarks containing the coordinates of different body points.
+ * @param {Function} onFeedbackUpdate A callback function that receives the feedback message about chest posture.
+ * @param {number} targetHipAngle The minimum hip angle (in degrees) for proper chest position (with slight forward lean).
+ * Chest should not drop below this angle.
+ */
+export const checkChestUp = (landmarks, onFeedbackUpdate, targetHipAngle = 45) => {
+    const leftShoulder = landmarks[11];
+    const leftHip = landmarks[23];
+    const leftKnee = landmarks[25];
+
+    const rightShoulder = landmarks[12];
+    const rightHip = landmarks[24];
+    const rightKnee = landmarks[26];
+
+    const leftHipAngle = calculateAngle(leftShoulder, leftHip, leftKnee);
+    const rightHipAngle = calculateAngle(rightShoulder, rightHip, rightKnee);
+
+    let feedback = "";
+
+    if (leftHipAngle < targetHipAngle || rightHipAngle < targetHipAngle) {
+        feedback = "Chest up!";
     }
 
     onFeedbackUpdate(feedback);


### PR DESCRIPTION
Not only should knee angle be measure in the Squats Page, but also hip angle. The hip angle is an indicator of whether or not the user is keeping their chest upright, which is an important element of proper squat form.
https://www.menshealth.com/fitness/a39110810/how-to-do-bodyweight-squats/

A new method checkChestUp has been added to Squats.js page. SquatPage pulls this and gives users feedback if their chest/hip falls below the minimum threshold. This minimum hip angle threshold can be adjusted by the user using the settings modal.