### PR TITLE
Incorporated tasks-vision model

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,6 +13,7 @@
         "@mediapipe/camera_utils": "^0.3.1675466862",
         "@mediapipe/drawing_utils": "^0.3.1675466124",
         "@mediapipe/pose": "^0.5.1675469404",
+        "@mediapipe/tasks-vision": "^0.10.17",
         "@mui/icons-material": "^6.1.3",
         "@mui/material": "^6.1.1",
         "@testing-library/jest-dom": "^5.17.0",
@@ -3952,6 +3953,11 @@
       "version": "0.5.1675469404",
       "resolved": "https://registry.npmjs.org/@mediapipe/pose/-/pose-0.5.1675469404.tgz",
       "integrity": "sha512-DFZsNWTsSphRIZppnUCuunzBiHP2FdJXR9ehc7mMi4KG+oPaOH0Em3d6kr7Py+TSyTXC1doH88KcF28k2sBxsQ=="
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg=="
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "6.1.3",

--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
     "@mediapipe/camera_utils": "^0.3.1675466862",
     "@mediapipe/drawing_utils": "^0.3.1675466124",
     "@mediapipe/pose": "^0.5.1675469404",
+    "@mediapipe/tasks-vision": "^0.10.17",
     "@mui/icons-material": "^6.1.3",
     "@mui/material": "^6.1.1",
     "@testing-library/jest-dom": "^5.17.0",

--- a/app/src/components/WebcamTasksVision.js
+++ b/app/src/components/WebcamTasksVision.js
@@ -1,0 +1,31 @@
+import React, { forwardRef } from 'react';
+import Webcam from 'react-webcam';
+
+/**
+ * WebcamBox is a React functional component that wraps the `react-webcam` component. 
+ * It hides the webcam feed by default but still allows access to the video stream through the ref.
+ *
+ * The webcam video stream uses the front-facing camera by default.
+ *
+ * @component
+ * @param {object} props Properties passed to the component.
+ * @param {React.Ref} ref Forwarded reference of the `Webcam` component. 
+ * @returns {JSX.Element} Hidden JSX div wrapping the `Webcam` component.
+ */
+const WebcamBox = forwardRef((props, ref) => {
+    return (
+        <div style={{ visibility: 'hidden', position: 'absolute' }}>
+            <Webcam
+                ref={ref}
+                className="hidden-webcam"
+                videoConstraints={{
+                    width: 640,
+                    height: 480,
+                    facingMode: "user",
+                }}
+            />
+        </div>
+    );
+});
+
+export default WebcamBox;

--- a/app/src/utils/PoseDetectorTasksVision.js
+++ b/app/src/utils/PoseDetectorTasksVision.js
@@ -1,0 +1,81 @@
+import {
+    FilesetResolver,
+    PoseLandmarker,
+    DrawingUtils,
+} from "@mediapipe/tasks-vision";
+import poseLandmarkerTask from "../shared/models/pose_landmarker_full.task";
+
+const detectPose = (webcamRef, canvasRef, onResultCallback) => {
+    let poseLandmarker;
+    let animationId;
+
+    const createPoseLandmarker = async () => {
+        try {
+            const vision = await FilesetResolver.forVisionTasks(
+                "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.0/wasm"
+            );
+            poseLandmarker = await PoseLandmarker.createFromOptions(
+                vision,
+                {
+                    baseOptions: {
+                        modelAssetPath: poseLandmarkerTask,
+                    },
+                    runningMode: "VIDEO",
+                    numPoses: 1,
+                }
+            );
+            detectPose();
+        } catch (e) {
+            console.error("ERROR:", e);
+        }
+    };
+
+    const detectPose = () => {
+        if (webcamRef.current && webcamRef.current.video.readyState >= 2) {
+            poseLandmarker.detectForVideo(
+                webcamRef.current.video,
+                performance.now(),
+                (result) => {
+                    const canvas = canvasRef.current;
+                    const canvasCtx = canvas.getContext("2d");
+                    const drawingUtils = new DrawingUtils(canvasCtx);
+
+                    canvasCtx.save();
+                    canvasCtx.clearRect(0, 0, canvas.width, canvas.height);
+                    canvasCtx.drawImage(
+                        webcamRef.current.video,
+                        0,
+                        0,
+                        canvas.width,
+                        canvas.height
+                    );
+                    for (const landmark of result.landmarks) {
+                        drawingUtils.drawLandmarks(landmark, {
+                            color: "red",
+                            radius: 2.5,
+                        });
+                        drawingUtils.drawConnectors(
+                            landmark,
+                            PoseLandmarker.POSE_CONNECTIONS,
+                            { color: "blue", lineWidth: 5 }
+                        );
+                    }
+                    canvasCtx.restore();
+                    if (result.landmarks[0]) {
+                        onResultCallback(result.landmarks[0]);
+                    }
+                }
+            );
+        }
+        animationId = requestAnimationFrame(detectPose);
+    };
+
+    createPoseLandmarker();
+
+    return () => {
+        if (poseLandmarker) poseLandmarker.close();
+        if (animationId) cancelAnimationFrame(animationId);
+    };
+};
+
+export default detectPose;


### PR DESCRIPTION
In React, it's not possible to dynamically switch file paths or components based on ENV variables, so I did not implement that part of the issue. There are two new files, PoseDetectorTasksVision.js and WebcamTasksVision.js which are there as substitutes for the PoseDetector.js and Webcam.js files except using the new tasks-vision model.